### PR TITLE
Fixed issue with README badges not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DroidEggs 
 
-![JIRA Issues](https://img.shields.io/badge/JIRA-Issues-blue) ![Build Status](https://travis-ci.org/itachi1706/DroidEggs.svg?branch=master)(https://travis-ci.org/itachi1706/DroidEggs)
+[![JIRA Issues](https://img.shields.io/badge/JIRA-Issues-blue)](https://jira.itachi1706.com:8123/browse/DEGGAND) [![Build Status](https://travis-ci.org/itachi1706/DroidEggs.svg?branch=master)](https://travis-ci.org/itachi1706/DroidEggs)
 
 An Android Application containing all of the Easter Eggs ever found on Android
 


### PR DESCRIPTION
When clicking on the badges, it will open an image of the badge instead of its intended intention of accessing the link itself. This fixes it

Badges Fixed:
- Travis CI Build Status badge
- JIRA link badge